### PR TITLE
chore: update Go version to 1.25

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.23' ]
+        go-version: [ '1.25' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.23' ]
+        go-version: [ '1.25' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Talk-Point/audithub-go-sdk
 
-go 1.23.0
+go 1.25


### PR DESCRIPTION
## Summary
- Updated `go.mod` from Go 1.23.0 to Go 1.25
- Updated CI workflow Go version matrix from 1.23 to 1.25
- Updated CD workflow Go version matrix from 1.23 to 1.25

## Related Issue
Relates to Talk-Point/IT#13762

## Test plan
- [ ] CI pipeline runs successfully with Go 1.25
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)