### PR TITLE
chore: update Go version to 1.25 (complete)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.23' ]
+        go-version: [ '1.25' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.23' ]
+        go-version: [ '1.25' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Talk-Point/audithub-go-sdk
 
-go 1.23.0
+go 1.25


### PR DESCRIPTION
## Summary
- Update go.mod from Go 1.23.0 to 1.25
- Update ci.yml matrix from 1.23 to 1.25
- Update cd.yml matrix from 1.23 to 1.25

## Files Changed
- `go.mod`
- `.github/workflows/ci.yml`
- `.github/workflows/cd.yml`

## Related Issue
Fixes https://github.com/Talk-Point/IT/issues/13762