### PR TITLE
ci: Go 1.26 (Workflows + go.mod + Dockerfile)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.25' ]
+        go-version: [ '1.26' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.25' ]
+        go-version: [ '1.26' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Talk-Point/audithub-go-sdk
 
-go 1.25
+go 1.26


### PR DESCRIPTION
Hebt Go auf 1.26 an. No-develop-Repo, daher PR gegen `master`. Refs: Talk-Point/IT#15822